### PR TITLE
Net-install modifications for KDE.

### DIFF
--- a/netinstall.yaml
+++ b/netinstall.yaml
@@ -38,11 +38,11 @@
   packages:
     - plasma
     - plasma-wayland-session
-    - discover
     - kde-applications
-    - powerdevil
     - xdg-user-dirs
     - packagekit-qt5
+    - elisa
+    - kdeconnect
 - name: "GNOME-Desktop"
   description: "GNOME Desktop - designed to put you in control and get things done. "
   hidden: false


### PR DESCRIPTION
Removing both discover and powerdevil (provided by plasma) and adding both elisa (music player) and KDE Connect.

Cf this forum post: https://forum.endeavouros.com/t/suggestion-needed-net-install-list-of-packages/1565/17