### PR TITLE
Adding back xdg-users to xfce net-install profile

### DIFF
--- a/netinstall.yaml
+++ b/netinstall.yaml
@@ -8,11 +8,13 @@
     - xfce4
     - xfce4-goodies
     - network-manager-applet
+    - xdg-user-dirs-gtk
+    - xdg-user-dirs
     - galculator
     - blueberry
     - lightdm
     - lightdm-gtk-greeter
-    - lightdm-gtk-greeter-settings
+    - lightdm-gtk-greeter-settings   
 - name: "MATE-Desktop"
   description: "MATE Desktop - the continuation of GNOME 2"
   hidden: false


### PR DESCRIPTION
Every single user directory (Documents, Downloads, Images, Templates, Videos, Public) are missing in a fresh xfce net-install on first start... Ouch!