### PR TITLE
Updating 08 08 2020

### DIFF
--- a/chrooted_cleaner_script.sh
+++ b/chrooted_cleaner_script.sh
@@ -84,7 +84,7 @@ _vmware() {
 }
 
 _common_systemd(){
-    local _systemd_enable=(NetworkManager vboxservice org.cups.cupsd avahi-daemon systemd-networkd-wait-online systemd-timesyncd tlp gdm lightdm sddm)   
+    local _systemd_enable=(NetworkManager vboxservice org.cups.cupsd avahi-daemon systemd-timesyncd tlp gdm lightdm sddm)   
     local _systemd_disable=(multi-user.target pacman-init)           
 
     local xx

--- a/cleaner_script.sh
+++ b/cleaner_script.sh
@@ -35,7 +35,7 @@ _copy_files(){
     local _files_to_copy=(
 
     
-    /etc/lightdm/*
+    /etc/lightdm/lightdm-gtk-greeter.conf
     /etc/sddm.conf.d/kde_settings.conf
 
     


### PR DESCRIPTION
https://github.com/endeavouros-team/install-scripts/blob/d08c2e88c8fb8a51aee771aef6ad1b21b816da89/cleaner_script.sh#L38
---> /etc/lightdm/* changed to  /etc/lightdm/lightdm-gtk-greeter.conf to not overwrite lightdm.conf for autologin.

https://github.com/endeavouros-team/install-scripts/blob/d08c2e88c8fb8a51aee771aef6ad1b21b816da89/chrooted_cleaner_script.sh#L87
---> removed systemd-networkd-wait-online