### PR TITLE
Replace mplayer with mpv

### DIFF
--- a/netinstall.yaml
+++ b/netinstall.yaml
@@ -97,7 +97,7 @@
     - gst-plugins-bad
     - gst-plugins-ugly
     - gst-plugin-pipewire
-    - mplayer
+    - mpv
     - libdvdcss
     - efibootmgr
     - dosfstools

--- a/netinstall_nvidia.yaml
+++ b/netinstall_nvidia.yaml
@@ -97,7 +97,7 @@
     - gst-plugins-bad
     - gst-plugins-ugly
     - gst-plugin-pipewire
-    - mplayer
+    - mpv
     - libdvdcss
     - efibootmgr
     - dosfstools


### PR DESCRIPTION
`mpv` is a fork of `mplayer` that is being actively developed.